### PR TITLE
[DEVX-449]: Transformations cleanup

### DIFF
--- a/clarifai_datautils/text/pipeline/cleaners.py
+++ b/clarifai_datautils/text/pipeline/cleaners.py
@@ -152,7 +152,10 @@ class Bytes_string_to_string(BaseTransform):
 
     """
     for element in elements:
-      element.text = bytes_string_to_string(element.text)
+      try:
+        element.text = bytes_string_to_string(element.text)
+      except ValueError:
+        continue
     return elements
 
 

--- a/clarifai_datautils/text/pipeline/extractors.py
+++ b/clarifai_datautils/text/pipeline/extractors.py
@@ -2,9 +2,9 @@ from typing import List
 
 from llama_index.core import Document
 from llama_index.core.node_parser import SentenceSplitter
-from unstructured.cleaners.extract import (
-    extract_datetimetz, extract_email_address, extract_ip_address, extract_ip_address_name,
-    extract_ordered_bullets, extract_text_after, extract_text_before)
+from unstructured.cleaners.extract import (extract_datetimetz, extract_email_address,
+                                           extract_ip_address, extract_ip_address_name,
+                                           extract_text_after, extract_text_before)
 from unstructured.documents.elements import Element, ElementMetadata
 
 from clarifai_datautils.constants.pipeline import MAX_NODES, SKIP_NODES
@@ -144,29 +144,6 @@ class ExtractIpAddressName(BaseTransform):
     """
     for element in elements:
       metadata = {'ip_address_name': extract_ip_address_name(element.text)}
-      element.metadata.update(ElementMetadata.from_dict(metadata))
-    return elements
-
-
-class ExtractOrderedBullets(BaseTransform):
-  """Extracts ordered bullets from text."""
-
-  def __init__(self):
-    """Initializes an ExtractOrderedBullets object."""
-    pass
-
-  def __call__(self, elements: List[str]) -> List[str]:
-    """Applies the transformation.
-
-    Args:
-        elements (List[str]): List of text elements.
-
-    Returns:
-        List of transformed text elements.
-
-    """
-    for element in elements:
-      metadata = {'ordered_bullets': extract_ordered_bullets(element.text)}
       element.metadata.update(ElementMetadata.from_dict(metadata))
     return elements
 

--- a/tests/pipelines/test_transformations.py
+++ b/tests/pipelines/test_transformations.py
@@ -6,9 +6,9 @@ from clarifai_datautils.text.pipeline.cleaners import (
     Bytes_string_to_string, Clean_bullets, Clean_dashes, Clean_extra_whitespace,
     Clean_non_ascii_chars, Clean_ordered_bullets, Clean_postfix, Clean_prefix,
     Group_broken_paragraphs, Remove_punctuation, Replace_unicode_quotes)
-from clarifai_datautils.text.pipeline.extractors import (
-    ExtractDateTimeTz, ExtractEmailAddress, ExtractIpAddress, ExtractIpAddressName,
-    ExtractOrderedBullets, ExtractTextAfter, ExtractTextBefore)
+from clarifai_datautils.text.pipeline.extractors import (ExtractDateTimeTz, ExtractEmailAddress,
+                                                         ExtractIpAddress, ExtractIpAddressName,
+                                                         ExtractTextAfter, ExtractTextBefore)
 
 
 class TestPipelineTransformations:
@@ -69,15 +69,6 @@ class TestPipelineTransformations:
             datetime.datetime(
                 2021, 3, 26, 11, 4, 9, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200)))
     }
-
-  def test_extractors_ordered_bullets(self,):
-    extractor = ExtractOrderedBullets()
-    element = extractor(
-        dict_to_elements([{
-            "text": """1. First bullet point, 2. Second bullet point, 3. Third bullet point""",
-            "type": "NarrativeText"
-        }]))
-    assert element[0].metadata.to_dict() == {'ordered_bullets': ('1', None, None)}
 
   def test_extractors_text_after(self,):
     extractor = ExtractTextAfter(key='text_after', string='this is the text after')


### PR DESCRIPTION
# Changed

- Error handling for bytes string to string
- Removed [ordered bullets extractors](https://docs.unstructured.io/open-source/core-functionality/extracting#extract-ordered-bullets:~:text=extract_mapi_id-,extract_ordered_bullets,-extract_text_after) since it only extracts alphanumeric bullets and adding that as a metadata was not very helpful
