### PR TITLE
fix: update dependencies and GitHub Actions for security

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.9'
       - name: Install dependencies

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,3 +1,3 @@
-setuptools==78.1.1
+setuptools==82.0.1
 build==1.2.1
 twine==5.1.1

--- a/.github/workflows/run_annotation_tests.yml
+++ b/.github/workflows/run_annotation_tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies for annotation tests

--- a/.github/workflows/run_annotation_tests.yml
+++ b/.github/workflows/run_annotation_tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies for annotation tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
         python -m nltk.downloader averaged_perceptron_tagger_eng
         python -m nltk.downloader punkt_tab
     - name: Run static analysis lint
-      uses: pre-commit/action@v3.0.1
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
     - name: Run pytest
       shell: bash
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
         python -m nltk.downloader averaged_perceptron_tagger_eng
         python -m nltk.downloader punkt_tab
     - name: Run static analysis lint
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1
     - name: Run pytest
       shell: bash
       run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # requirements-dev.txt
 unstructured[pdf] @ git+https://github.com/clarifai/unstructured.git@support_clarifai_model
 pdfminer.six==20251230
-llama-index-core==0.13.0
+llama-index-core==0.14.21
 llama-index-llms-clarifai==0.5.0
 pi_heif==0.18.0
-markdown==3.8.1
+markdown==3.10.2
 python-docx==1.1.2
 schema==0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-llama-index-core==0.13.0
+llama-index-core==0.14.21
 llama-index-llms-clarifai==0.5.0
 pi_heif==0.18.0
-markdown==3.8.1
+markdown==3.10.2
 python-docx==1.1.2
 schema==0.7.5

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
 pytest==9.0.3
-pytest-xdist==2.5.0
+pytest-xdist==3.8.0


### PR DESCRIPTION
Update outdated dependencies to latest secure versions:
- pytest-xdist: 2.5.0 → 3.8.0 (2 years of security updates)
- setuptools: 78.1.1 → 82.0.1 (latest security patches)
- llama-index-core: 0.13.0 → 0.14.21 (bug fixes and improvements)
- markdown: 3.8.1 → 3.10.2 (security patches)

Update GitHub Actions to latest versions:
- actions/setup-python: v4 → v5 (Node.js 20 runtime, security improvements)
- pre-commit/action: v3.0.0 → v3.0.1 (latest patch fixes)

All updates verified for compatibility with no conflicts detected.